### PR TITLE
Support Browser field

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,16 @@ Usage:
   devtool [entry] [opts]
 
 Options:
-  --watch, -w     enable file watching (for development)
-  --quit, -q      quit application on fatal errors
-  --console, -c   redirect console logs to terminal
-  --index, -i     specify a different index.html file
-  --poll, -p      enable polling when --watch is given
-  --show, -s      show the browser window (default false)
-  --headless, -h  do not open the DevTools window
+  --watch, -w             enable file watching (for development)
+  --quit, -q              quit application on fatal errors
+  --console, -c           redirect console logs to terminal
+  --index, -i             specify a different index.html file
+  --poll, -p              enable polling when --watch is given
+  --show, -s              show the browser window (default false)
+  --headless, -h          do not open the DevTools window
+  --browser-field, --bf   resolve using "browser" field
+  
+                  
 ```
 
 Examples:
@@ -57,6 +60,8 @@ devtool
 ```
 
 You can specify `--watch` multiple times to watch different files/globs. If a custom `--index` is passed, it will also be watched for changes. 
+
+The `--browser-field` makes the `require()` statements respect the [package.json `"browser"` field](https://gist.github.com/defunctzombie/4339901).
 
 ## Use Cases
 
@@ -108,10 +113,12 @@ devtool
 
 You can also mix Node modules with browser APIs, such as Canvas and WebGL. See [example/streetview.js](./example/streetview.js) and the respective script in [package.json](./package.json), which grabs a StreetView panorama with some [Google Client APIs](https://developers.google.com/discovery/libraries?hl=en) and writes the PNG image to `process.stdout`.
 
+For this, you may want to use the `--bf` or `--browser-field` flag so that modules like [nets](http://npmjs.com/package/nets) will use Web APIs where possible.
+
 Example:
 
 ```sh
-devtool street.js --index street.html --quit > street.png
+devtool street.js --index street.html --quit --bf > street.png
 ```
 
 Result:
@@ -151,7 +158,6 @@ Since this is running in Electron and Chromium, instead of Node, you might run i
 This project is experimental and has not been tested on a wide range of applications or Node/OS environments. If you want to help, please open an issue or submit a PR. Some outstanding areas to explore:
 
 - Adding a `--timeout` option to auto-close after X seconds
-- Supporting `"browser"` field in `package.json`
 - Supporting `process.stdin` and piping
 - Improving syntax error handling, e.g. adding it to Sources panel
 - Exposing an API for programmatic usage

--- a/example/streetview.js
+++ b/example/streetview.js
@@ -1,6 +1,8 @@
 /*
   Using Google Client Libraries with Node.js APIs.
   This demo uses a custom `streetview.html` index.
+  This uses the --browser-field flag to resolve
+  our require flags.
 
     npm run streetview
  */
@@ -8,7 +10,7 @@
 var awesome = require('awesome-streetview');
 var render = require('google-panorama-equirectangular');
 var toBuffer = require('electron-canvas-to-buffer');
-var googlePano = require('google-panorama-by-location/browser');
+var googlePano = require('google-panorama-by-location');
 
 googlePano(awesome(), function (err, result) {
   if (err) throw err;

--- a/lib/preload.js
+++ b/lib/preload.js
@@ -47,7 +47,8 @@
   //  - add source maps so the files show up in DevTools Sources
   requireHook({
     entry: entry,
-    basedir: cwd
+    basedir: cwd,
+    browserField: remote.getGlobal('__electronBrowserResolve')
   }, function (err) {
     if (err && shouldQuit) {
       fatalError(err);

--- a/lib/require-hook.js
+++ b/lib/require-hook.js
@@ -15,6 +15,8 @@ module.exports = function requireHook (opts, cb) {
   var fs = remote.require('fs');
   var stripBOM = require('strip-bom');
   var combineSourceMap = require('combine-source-map');
+  var browserResolve = require('browser-resolve');
+
   var entry = opts.entry;
   var basedir = opts.basedir || remote.process.cwd();
 
@@ -59,4 +61,21 @@ module.exports = function requireHook (opts, cb) {
       sourceMap.comment()
     ].join('\n');
   };
+
+  // Use browser field resolution for require statements
+  if (opts.browserField) {
+    var nativeResolve = Module._resolveFilename;
+    Module._resolveFilename = function (filename, parent) {
+      try {
+        // Try to use a browser resolver first...
+        return browserResolve.sync(filename, {
+          filename: parent.filename,
+          paths: parent.paths
+        });
+      } catch (e) {
+        // Otherwise fall back to native; e.g. for Electron requires
+        return nativeResolve.call(Module, filename, parent);
+      }
+    };
+  }
 };

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "faucet": "0.0.1",
     "google-panorama-by-location": "^4.1.1",
     "google-panorama-equirectangular": "^1.2.0",
-    "tape": "^4.4.0",
-    "xhr-request": "^1.0.1"
+    "tape": "^4.4.0"
   },
   "scripts": {
     "test": "node test/index.js | faucet",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/mattdesl"
   },
   "dependencies": {
+    "browser-resolve": "^1.11.0",
     "chokidar": "^1.4.2",
     "combine-source-map": "^0.7.1",
     "console-redirect": "^1.0.0",
@@ -31,7 +32,8 @@
     "faucet": "0.0.1",
     "google-panorama-by-location": "^4.1.1",
     "google-panorama-equirectangular": "^1.2.0",
-    "tape": "^4.4.0"
+    "tape": "^4.4.0",
+    "xhr-request": "^1.0.1"
   },
   "scripts": {
     "test": "node test/index.js | faucet",
@@ -39,7 +41,7 @@
     "geolocate": "./bin/index.js example/geolocate.js -qch",
     "es2015": "./bin/index.js example/es2015.js -w -i example/es2015.html",
     "browserify": "./bin/index.js example/browserify.js -qch",
-    "streetview": "./bin/index.js example/streetview.js -i example/streetview.html -q > example/streetview.png"
+    "streetview": "./bin/index.js example/streetview.js -i example/streetview.html -q --bf > example/streetview.png"
   },
   "keywords": [],
   "repository": {

--- a/server.js
+++ b/server.js
@@ -8,10 +8,14 @@ var BrowserWindow = electron.BrowserWindow;
 var ipc = electron.ipcMain;
 
 var argv = require('minimist')(process.argv.slice(2), {
-  boolean: [ 'console', 'quit', 'poll', 'show', 'headless' ],
+  boolean: [
+    'console', 'quit', 'poll', 'show', 'headless',
+    'browser-field'
+  ],
   string: [ 'index' ],
   alias: {
     headless: 'h',
+    'browser-field': [ 'bf', 'browserField' ],
     watch: 'w',
     quit: 'q',
     console: 'c',
@@ -28,6 +32,7 @@ app.commandLine.appendSwitch('vmodule', 'console=0');
 global.__shouldElectronQuitOnError = true; // true until app starts
 global.__electronEntryFile = argv._[0];
 global.__electronConsoleHook = argv.console;
+global.__electronBrowserResolve = argv.browserField;
 
 var exitWithCode1 = false;
 process.on('uncaughtException', function (err) {


### PR DESCRIPTION
With `--browser-field` or `--bf`, require statements will be resolved like they are in webpack/browserify. This can be handy for debugging HTTP requests, for visual programs like canvas/WebGL manipulators, etc.

This is still a bit experimental, but it seems to work for the cases I'm testing.