### PR TITLE
Updated electron version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "chokidar": "^1.4.2",
     "combine-source-map": "^0.7.1",
     "console-redirect": "^1.0.0",
-    "electron-prebuilt": "^0.35.6",
+    "electron-prebuilt": "^0.36.4",
     "events": "^1.1.0",
     "minimist": "^1.2.0",
     "object-assign": "^4.0.1",


### PR DESCRIPTION
Updated electron package version to the latest.

Without this Babel 6 via require hook would not work if using `util.inherits`, investigation seemed to point towards "use strict" and Object.prototype being read only, seems babel or electron was forcing strictness in that scenario on the older version. 

**Error stack:**
```text
/MY_PROJECT_DIR/node_modules/babel-core/lib/transformation/file/index.js:548
      throw err;
      ^

TypeError: /MY_PROJECT_DIR/api/hooks/hive/queue.js: Cannot set property 'Symbol(should not be considered a local binding)' of undefined
    at Object.push (/MY_PROJECT_DIR/node_modules/babel-plugin-transform-es2015-classes/node_modules/babel-helper-define-map/lib/index.js:96:37)
    at [object Object].pushToMap (/MY_PROJECT_DIR/node_modules/babel-plugin-transform-es2015-classes/lib/vanilla.js:191:25)
    at [object Object].pushMethod (/MY_PROJECT_DIR/node_modules/babel-plugin-transform-es2015-classes/lib/vanilla.js:531:10)
    at [object Object].pushBody (/MY_PROJECT_DIR/node_modules/babel-plugin-transform-es2015-classes/lib/vanilla.js:312:16)
    at [object Object].buildBody (/MY_PROJECT_DIR/node_modules/babel-plugin-transform-es2015-classes/lib/vanilla.js:244:10)
    at [object Object].run (/MY_PROJECT_DIR/node_modules/babel-plugin-transform-es2015-classes/lib/vanilla.js:151:10)
    at PluginPass.ClassExpression (/MY_PROJECT_DIR/node_modules/babel-plugin-transform-es2015-classes/lib/index.js:63:60)
    at newFn (/MY_PROJECT_DIR/node_modules/babel-traverse/lib/visitors.js:293:19)
    at NodePath._call (/MY_PROJECT_DIR/node_modules/babel-traverse/lib/path/context.js:74:18)
    at NodePath.call (/MY_PROJECT_DIR/node_modules/babel-traverse/lib/path/context.js:46:17)
    at NodePath.visit (/MY_PROJECT_DIR/node_modules/babel-traverse/lib/path/context.js:104:12)
    at TraversalContext.visitQueue (/MY_PROJECT_DIR/node_modules/babel-traverse/lib/context.js:153:16)
    at TraversalContext.visitSingle (/MY_PROJECT_DIR/node_modules/babel-traverse/lib/context.js:113:19)
    at TraversalContext.visit (/MY_PROJECT_DIR/node_modules/babel-traverse/lib/context.js:197:19)
    at Function.traverse.node (/MY_PROJECT_DIR/node_modules/babel-traverse/lib/index.js:139:17)
    at NodePath.visit (/MY_PROJECT_DIR/node_modules/babel-traverse/lib/path/context.js:114:22)
    at TraversalContext.visitQueue (/MY_PROJECT_DIR/node_modules/babel-traverse/lib/context.js:153:16)
```

Tried disabling various babel plugins to no effect, in the end the Electron update did the trick.

Preset `babel-preset-es2015-node5` now works perfectly. As does just `es2015`.


