### PR TITLE
Added feature to quit app when devtools closed and no window shown

### DIFF
--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -69,11 +69,24 @@ function createMainWindow (entry, url, argv, onReady) {
     webContents.once('devtools-opened', function () {
       // Hide the main window frame so windows
       // users aren't seeing a tiny frame.
-      if (!argv.show) mainWindow.hide();
+      if (!argv.show) {
+        mainWindow.hide();
+
+        // If only devtools are shown and now window
+        // quit app when devtools is closed.
+        // Used setImmediate because the event was thrown before devtools opened
+        // and process.nextTick didn't work
+        setImmediate(function () {
+          webContents.once('devtools-closed', function () {
+            electron.app.quit();
+          });
+        });
+      }
 
       // Run app
       run();
     });
+
 
     // Launch debugger
     var detach = config.detachDevTools !== false;


### PR DESCRIPTION
When running devtool without a browser window and only devtools visible, the process continues running when closing the devtools window. This commit fixes that issue.