### PR TITLE
Don't touch process.stdin

### DIFF
--- a/lib/preload.js
+++ b/lib/preload.js
@@ -114,16 +114,16 @@
 
     // renderer streams should have same isTTY as main
     var isTTY = globals._processTTY;
-    process.stdin.isTTY = isTTY.stdin;
+    //process.stdin.isTTY = isTTY.stdin;
     process.stdout.isTTY = isTTY.stdout;
     process.stderr.isTTY = isTTY.stderr;
-    process.stdin._read = function () {
-      this.push('');
-    };
+    //process.stdin._read = function () {
+    //  this.push('');
+    //};
 
     // send along any stdin
-    ipc.on('stdin', function (event, data) {
-      process.stdin.push(data);
-    });
+    // ipc.on('stdin', function (event, data) {
+    //  process.stdin.push(data);
+    //});
   }
 })();


### PR DESCRIPTION
Commenting the lines that refer to `process.stdin` prevents the windows error messages on https://github.com/Jam3/devtool/issues/42 

Maybe we should add `if (/^win/.test(process.platform))` on those lines or find a real fix for the stdin problem.