### PR TITLE
Don’t modify existing sourceMaps unless needed

### DIFF
--- a/lib/require-hook.js
+++ b/lib/require-hook.js
@@ -52,6 +52,9 @@ module.exports = function requireHook (opts) {
   // Include source maps for required modules
   var wrap = Module.wrap;
   Module.wrap = function devtoolWrapModule (script) {
+    // If no options that require it, don't modify script contents
+    if (!opts.debugBreak && opts.browserGlobals) return wrap.call(Module, script)
+
     // Setup source maps and inject a hidden debugger statement
     var original = script;
     if (opts.debugBreak && currentWrapFile === entry) {

--- a/server.js
+++ b/server.js
@@ -87,9 +87,15 @@ app.on('ready', function () {
     if (file === mainIndexURL) {
       file = htmlFile;
     } else if (file.indexOf('file://') === 0) {
-      // All other assets should be relative to the user's cwd
+      // Relative paths in the page are requested relative to the devtools
+      // install directory. Adjust these paths to be relative to the cwd instead.
+      // Absolute paths will not be relative to the devtools install directory
+      // and therefore begin with a `..`. These paths can be preserved.
       file = file.substring(7);
-      file = path.resolve(cwd, path.relative(__dirname, file));
+      var relativePath = path.relative(__dirname, file);
+      if (relativePath.indexOf('..') !== 0) {
+        file = path.resolve(cwd, relativeFile);
+      }
     }
 
     fs.readFile(file, function (err, data) {


### PR DESCRIPTION
Refs https://github.com/Jam3/devtool/issues/56

If requiring files that already have inline source maps, the changes made by the devtools Module.wrap hook cause the existing source maps to be discarded in some circumstances. This avoids this issue in cases when the `--break` or `--no-browser-globals` flags are not specified.