### PR TITLE
Fix for mixed setTimeout/clearTimeout methods

### DIFF
--- a/lib/timer-hook.js
+++ b/lib/timer-hook.js
@@ -10,6 +10,8 @@ var timers = require('timers');
 module.exports = function timerHook () {
   global.setTimeout = wrapWithActivateUvLoop(timers.setTimeout);
   global.setInterval = wrapWithActivateUvLoop(timers.setInterval);
+  global.clearTimeout = timers.clearTimeout;
+  global.clearInterval = timers.clearInterval;
 };
 
 function wrapWithActivateUvLoop (func) {


### PR DESCRIPTION
Noticed that I was unable to use clearTimeout but inly when running through devtool, it looks like we need to shim both setTimeout and clearTimeout otherwise we get the setTimeout method from node and the clearTimeout method from the browser. 

Maybe there is a better place to setup protection for clearTimeout/clearInterval? but this seems to work for me.

Thats not fun 👎 