### PR TITLE
update to electron@1.4.3

### DIFF
--- a/bin/spawn.js
+++ b/bin/spawn.js
@@ -1,6 +1,6 @@
 // spawns devtool with given CLI arguments
 const spawn = require('child_process').spawn;
-const electron = require('electron-prebuilt');
+const electron = require('electron');
 const through = require('through2');
 const path = require('path');
 const parseArgs = require('../lib/parse-args').fromArray;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "concat-stream": "^1.5.1",
     "convert-source-map": "^1.2.0",
     "deep-extend": "^0.4.1",
-    "electron-prebuilt": "1.3.3",
+    "electron": "1.4.3",
     "events": "^1.1.0",
     "mime": "^1.3.4",
     "minimist": "^1.2.0",


### PR DESCRIPTION
Updates the version, and switch from `electron-prebuilt` to `electron`.