### PR TITLE
Add additional ignored files using .devtoolrc

### DIFF
--- a/lib/file-watch.js
+++ b/lib/file-watch.js
@@ -10,6 +10,8 @@ var ignores = [
 ];
 
 module.exports = function fileWatch (glob, opt) {
+  if(opt.config.watcher.ignored)  ignores = ignores.concat(opt.config.watcher.ignored);
+  
   opt = assign({
     ignored: ignores,
     ignoreInitial: true


### PR DESCRIPTION
It would be amazing if this is accepted, This way I can add `"watcher": { "ignored": "public"}` to the .devtoolrc to extend the files I want to be ignored from watching :)