### PR TITLE
fix: emit process 'exit' event on window close

### DIFF
--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -55,6 +55,10 @@ function createMainWindow (entry, url, argv, onReady) {
     closed = true;
   });
 
+  mainWindow.on('close', function () {
+    process.emit('exit', 0);
+  });
+
   // On first load, we trigger the app execution
   var webContents = mainWindow.webContents;
 


### PR DESCRIPTION
This allows for proper NodeJS-style cleanup before the window closes.

**PS:** You can add me as a contributor too. 😄 