### PR TITLE
feat: require ./ or ../ from the REPL

### DIFF
--- a/lib/require-hook.js
+++ b/lib/require-hook.js
@@ -18,6 +18,14 @@ module.exports = function requireHook (opts) {
   var hasSetMain = false;
   var currentWrapFile = null;
 
+  var loadModule = Module._load;
+  Module._load = function(request, parent, isMain) {
+    if (request[0] === '.' && parent.id === '.') {
+      request = path.resolve(request);
+    }
+    return loadModule(request, parent, isMain);
+  };
+
   require.extensions['.js'] = function devtoolCompileModule (module, file) {
     // set the main module so that Node.js scripts run correctly
     if (!hasSetMain && entry && file === entry) {


### PR DESCRIPTION
Assume the user wants to require a module that is relative to the directory they started `devtool` from.